### PR TITLE
Add support to Laravel 11

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### What kind of change does this PR introduce?
+Bugfix, feature, changelog, release, docs update, etc.
+
+### What is the new behavior?
+Close [xxx](https://coverzen.atlassian.net/browse/xxx)
+
+### Does this PR introduce a breaking change?
+No
+
+### Other information:
+N/A

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,9 +15,9 @@ jobs:
         stability: [ prefer-lowest, prefer-stable ]
         include:
           - laravel: '10.*'
-            testbench: '8.*'
+            testbench: '^8.22'
           - laravel: '11.*'
-            testbench: '9.*'
+            testbench: '^9.11'
 
     name: Laravel ${{ matrix.laravel }} - ${{ matrix.stability }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,12 +2,24 @@ name: Tests
 on:
   workflow_call:
 
-
 jobs:
   tests:
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
+
+    strategy:
+      fail-fast: true
+      matrix:
+        laravel: [ '10.*', '11.*' ]
+        stability: [ prefer-lowest, prefer-stable ]
+        include:
+          - laravel: '10.*'
+            testbench: '8.*'
+          - laravel: '11.*'
+            testbench: '9.*'
+
+    name: Laravel ${{ matrix.laravel }} - ${{ matrix.stability }}
 
     services:
       localstack:
@@ -43,7 +55,9 @@ jobs:
             ${{ runner.os }}-composer-
 
       - name: Install Composer dependencies
-        run: composer install -n --prefer-dist
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Run tests
         run: composer test

--- a/composer.json
+++ b/composer.json
@@ -9,17 +9,12 @@
     }],
     "require": {
         "php": "^8.2",
-        "aws/aws-sdk-php": "^3.304",
-        "illuminate/contracts": "^10.0",
-        "illuminate/queue": "^10.0",
-        "illuminate/support": "^10.0"
+        "aws/aws-sdk-php": "^3.304"
     },
     "require-dev": {
-        "fakerphp/faker": "^1.23",
         "friendsofphp/php-cs-fixer": "^3.53",
-        "mockery/mockery": "^1.6",
         "nunomaduro/phpinsights": "^2.11",
-        "orchestra/testbench": "^8.22",
+        "orchestra/testbench": "^9.0",
         "pestphp/pest": "^2.34",
         "pestphp/pest-plugin-arch": "^2.7",
         "pestphp/pest-plugin-laravel": "^2.3",
@@ -29,14 +24,14 @@
         "phpstan/phpstan-mockery": "^1.1",
         "phpstan/phpstan-phpunit": "^1.3",
         "povils/phpmnd": "^3.4",
+        "roave/security-advisories": "dev-latest",
         "squizlabs/php_codesniffer": "^3.9",
         "timacdonald/log-fake": "^2.2"
     },
     "autoload": {
         "psr-4": {
             "Coverzen\\ConfigurableSqs\\": "src/",
-            "Coverzen\\ConfigurableSqs\\Tests\\": "tests/",
-            "Workbench\\App\\": "workbench/app/"
+            "Coverzen\\ConfigurableSqs\\Tests\\": "tests/"
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.53",
         "nunomaduro/phpinsights": "^2.11",
-        "orchestra/testbench": "^9.0",
+        "orchestra/testbench": "^8.22||^9.0",
         "pestphp/pest": "^2.34",
         "pestphp/pest-plugin-arch": "^2.7",
         "pestphp/pest-plugin-laravel": "^2.3",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.53",
         "nunomaduro/phpinsights": "^2.11",
-        "orchestra/testbench": "^8.22||^9.0",
+        "orchestra/testbench": "^8.22||^9.11",
         "pestphp/pest": "^2.34",
         "pestphp/pest-plugin-arch": "^2.7",
         "pestphp/pest-plugin-laravel": "^2.3",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,13 +20,7 @@
             <directory suffix="Test.php">tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
+    <coverage/>
     <logging>
         <junit outputFile="build/report.junit.xml"/>
     </logging>


### PR DESCRIPTION
### What kind of change does this PR introduce?
Update

### What is the new behavior?

- Close [CZDEV-7990](https://coverzen.atlassian.net/browse/CZDEV-7990)
- Add supporto to Laravel 11
- Add matrix to check compatibility both with Laravel 10 and Laravel 11

### Does this PR introduce a breaking change?
No

### Other information:
N/A
