### PR TITLE
Add Laravel 12 support

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,7 +1,7 @@
 name: configurable-sqs
 type: php
 docroot: ""
-php_version: "8.2"
+php_version: "8.3"
 webserver_type: nginx-fpm
 xdebug_enabled: false
 additional_hostnames: []

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,13 +11,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        laravel: [ '10.*', '11.*' ]
+        laravel: [ '11.*', '12.*' ]
         stability: [ prefer-lowest, prefer-stable ]
         include:
-          - laravel: '10.*'
-            testbench: '^8.22'
           - laravel: '11.*'
             testbench: '^9.11'
+          - laravel: '12.*'
+            testbench: '^10.0'
 
     name: Laravel ${{ matrix.laravel }} - ${{ matrix.stability }}
 

--- a/composer.json
+++ b/composer.json
@@ -8,16 +8,16 @@
         "email": "francesco.giovannini@coverzen.it"
     }],
     "require": {
-        "php": "^8.2",
+        "php": "^8.2||^8.3",
         "aws/aws-sdk-php": "^3.304"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.53",
         "nunomaduro/phpinsights": "^2.11",
-        "orchestra/testbench": "^8.22||^9.11",
-        "pestphp/pest": "^2.34",
-        "pestphp/pest-plugin-arch": "^2.7",
-        "pestphp/pest-plugin-laravel": "^2.3",
+        "orchestra/testbench": "^8.22||^9.11||^10.0",
+        "pestphp/pest": "^2.34||^3.0",
+        "pestphp/pest-plugin-arch": "^2.7||^3.0",
+        "pestphp/pest-plugin-laravel": "^2.3||^3.0",
         "phpmd/phpmd": "^2.15",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan": "^1.10",
@@ -37,7 +37,7 @@
     "scripts": {
         "analyse": [
             "@cs",
-            "@csfixer",
+            "@php-cs-fixer",
             "@insights",
             "@md",
             "@mnd",
@@ -45,9 +45,9 @@
         ],
         "test": "vendor/bin/pest",
         "cs": "vendor/bin/phpcs",
-        "csfixer": "vendor/bin/php-cs-fixer fix --no-interaction --dry-run --diff --stop-on-violation",
-        "csfixer-fix": "./vendor/bin/php-cs-fixer fix",
-        "insights": "vendor/bin/phpinsights",
+        "php-cs-fixer": "vendor/bin/php-cs-fixer fix --no-interaction --dry-run --diff --stop-on-violation",
+        "php-cs-fixer-fix": "./vendor/bin/php-cs-fixer fix",
+        "insights": "vendor/bin/phpinsights -n",
         "md": "vendor/bin/phpmd --cache src text phpmd.xml",
         "mnd": "vendor/bin/phpmnd --extensions=all,-property --allow-array-mapping src",
         "stan": "vendor/bin/phpstan analyse -v --no-interaction --memory-limit=1G"

--- a/src/Job/ConfigurableCallQueuedHandler.php
+++ b/src/Job/ConfigurableCallQueuedHandler.php
@@ -99,12 +99,13 @@ final class ConfigurableCallQueuedHandler extends CallQueuedHandler
     /**
      * @param array $data
      * @param $e
-     * @param mixed $uuid
+     * @param string $uuid
+     * @param ?Job $job
      *
      * @throws BindingResolutionException
      * @return void
      */
-    public function failed(array $data, $e, mixed $uuid): void
+    public function failed(array $data, $e, string $uuid, ?Job $job = null): void
     {
         /** @var mixed $command */
         $command = $this->container->make(Arr::get($data, 'commandName'));

--- a/src/Sqs/ConfigurableQueue.php
+++ b/src/Sqs/ConfigurableQueue.php
@@ -68,7 +68,7 @@ final class ConfigurableQueue extends SqsQueue
     /**
      * {@inheritdoc}
      */
-    protected function createPayload($job, $queue, $data = ''): false|string
+    protected function createPayload($job, $queue, $data = '', $delay = null): false|string
     {
         if (!$job instanceof SimpleSQSJob) {
             return parent::createPayload($job, $queue, $data);


### PR DESCRIPTION
### What kind of change does this PR introduce?
Feature

### What is the new behavior?
Close [CZDEV-1171](https://coverzen.atlassian.net/browse/CZDEV-1171)
Update laravel/framework constraint to support Laravel 12. 
[DUAL COMPATIBILITY: Maintains Laravel 11 compatibility]

### Does this PR introduce a breaking change?
No

### Other information:
N/A
